### PR TITLE
Add Bigtable Java client metrics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,11 +86,11 @@ jobs:
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: mkdir -p target .js/target site/target .jvm/target .native/target cats-effect/target refreshable/target trace4cats/target project/target
+        run: mkdir -p target .js/target site/target .jvm/target .native/target opencensus/target cats-effect/target refreshable/target bigtable/target trace4cats/target project/target
 
       - name: Compress target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
-        run: tar cf targets.tar target .js/target site/target .jvm/target .native/target cats-effect/target refreshable/target trace4cats/target project/target
+        run: tar cf targets.tar target .js/target site/target .jvm/target .native/target opencensus/target cats-effect/target refreshable/target bigtable/target trace4cats/target project/target
 
       - name: Upload target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/bigtable/src/main/scala/prometheus4cats/bigtable/BigtableOpenCensusMetrics.scala
+++ b/bigtable/src/main/scala/prometheus4cats/bigtable/BigtableOpenCensusMetrics.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package prometheus4cats.bigtable
 
 import cats.effect.kernel.{Resource, Sync}

--- a/bigtable/src/main/scala/prometheus4cats/bigtable/BigtableOpenCensusMetrics.scala
+++ b/bigtable/src/main/scala/prometheus4cats/bigtable/BigtableOpenCensusMetrics.scala
@@ -1,0 +1,32 @@
+package prometheus4cats.bigtable
+
+import cats.effect.kernel.{Resource, Sync}
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings
+import prometheus4cats.{MetricCollection, MetricFactory}
+import prometheus4cats.opencensus.OpenCensusUtils
+
+object BigtableOpenCensusMetrics {
+  private[bigtable] val openCensusPrefix = "cloud.google.com/java/bigtable/"
+
+  private[bigtable] def metricCollection[F[_]: Sync]: F[MetricCollection] =
+    OpenCensusUtils
+      .openCensusAsMetricCollection[F]("bigtable_client")(
+        _.getMetricDescriptor.getName
+          .startsWith(openCensusPrefix),
+        _.replace(openCensusPrefix, "bigtable_")
+      )
+
+  private[bigtable] def enableClientMetrics[F[_]: Sync]: F[Unit] =
+    Sync[F].blocking {
+      BigtableDataSettings.enableOpenCensusStats()
+      BigtableDataSettings.enableGfeOpenCensusStats()
+    }
+
+  def register[F[_]: Sync](
+      metricFactory: MetricFactory.WithCallbacks[F]
+  ): Resource[F, Unit] =
+    metricFactory.dropPrefix
+      .metricCollectionCallback(metricCollection)
+      .build
+      .evalMap(_ => enableClientMetrics)
+}

--- a/bigtable/src/test/scala/prometheus4cats/bigtable/BigtableOpenCensusMetricsSuite.scala
+++ b/bigtable/src/test/scala/prometheus4cats/bigtable/BigtableOpenCensusMetricsSuite.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package prometheus4cats.bigtable
 
 import cats.data.NonEmptySeq

--- a/bigtable/src/test/scala/prometheus4cats/bigtable/BigtableOpenCensusMetricsSuite.scala
+++ b/bigtable/src/test/scala/prometheus4cats/bigtable/BigtableOpenCensusMetricsSuite.scala
@@ -1,0 +1,153 @@
+package prometheus4cats.bigtable
+
+import cats.data.NonEmptySeq
+import cats.effect.syntax.resource._
+import cats.effect.{IO, Resource}
+import cats.syntax.flatMap._
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest
+import com.google.cloud.bigtable.admin.v2.{
+  BigtableTableAdminClient,
+  BigtableTableAdminSettings
+}
+import com.google.cloud.bigtable.data.v2.models.RowMutation
+import com.google.cloud.bigtable.data.v2.{
+  BigtableDataClient,
+  BigtableDataSettings
+}
+import com.google.cloud.bigtable.emulator.v2.Emulator
+import io.opencensus.metrics.Metrics
+import munit.CatsEffectSuite
+import prometheus4cats.MetricCollection.Value
+import prometheus4cats.MetricCollection.Value.LongGauge
+import prometheus4cats.{Label, MetricCollection}
+
+import scala.jdk.CollectionConverters._
+
+class BigtableOpenCensusMetricsSuite extends CatsEffectSuite {
+
+  val setupInstance = BigtableOpenCensusMetrics
+    .enableClientMetrics[IO]
+    .toResource >> IO(Emulator.createBundled()).toResource
+    .flatTap(e => Resource.make(IO(e.start()))(_ => IO(e.stop())))
+    .evalMap { bigtableEmulator =>
+      val dataSettings = BigtableDataSettings
+        .newBuilderForEmulator(bigtableEmulator.getPort)
+        .setProjectId("test")
+        .setInstanceId("test")
+
+      val tableAdminSettings = BigtableTableAdminSettings
+        .newBuilderForEmulator(bigtableEmulator.getPort)
+        .setProjectId("test")
+        .setInstanceId("test")
+
+      val tableAdminClient =
+        BigtableTableAdminClient.create(tableAdminSettings.build())
+
+      val dataClient = BigtableDataClient.create(dataSettings.build())
+
+      IO(
+        tableAdminClient.createTable(
+          CreateTableRequest
+            .of("test-table")
+            .addFamily("cf")
+        )
+      ) >> IO(
+        dataClient.mutateRow(
+          RowMutation
+            .create("test-table", "test-key")
+            .setCell("cf", "col", "value")
+        )
+      )
+    }
+
+  test("label names and values are the same size") {
+
+    def testLabels[A](
+        map: Map[(A, IndexedSeq[Label.Name]), List[MetricCollection.Value]]
+    ) =
+      map.foreach { case ((name, labelNames), values) =>
+        values.foreach(v =>
+          assertEquals(
+            labelNames.size,
+            v.labelValues.size,
+            s"Label names and values are not the same size for $name"
+          )
+        )
+      }
+
+    setupInstance.surround(
+      BigtableOpenCensusMetrics.metricCollection[IO].map { collection =>
+        testLabels(collection.gauges)
+        testLabels(collection.counters)
+        testLabels(collection.histograms)
+        testLabels(collection.summaries)
+      }
+    )
+
+  }
+
+  test("histogram buckets are expected size") {
+
+    setupInstance.surround(
+      BigtableOpenCensusMetrics
+        .metricCollection[IO]
+        .map(_.histograms.foreach { case ((name, _), values) =>
+          def test[A](buckets: NonEmptySeq[A], bucketValues: NonEmptySeq[A]) =
+            assertEquals(
+              buckets.length + 1,
+              bucketValues.length,
+              s"Incorrect bucket values length for histogram ${name.value}. " +
+                "The number of bucket values must always be 1 greater than number of defined buckets"
+            )
+
+          values.foreach {
+            case Value.LongHistogram(buckets, _, _, value) =>
+              test(buckets, value.bucketValues)
+            case Value.DoubleHistogram(buckets, _, _, value) =>
+              test(buckets, value.bucketValues)
+          }
+
+        })
+    )
+
+  }
+
+  test("exports expected metrics") {
+    setupInstance.surround(
+      IO.blocking(
+        Metrics.getExportComponent.getMetricProducerManager.getAllMetricProducer.asScala.toList
+          .flatMap(_.getMetrics.asScala)
+          .filter(
+            _.getMetricDescriptor.getName
+              .startsWith(BigtableOpenCensusMetrics.openCensusPrefix)
+          )
+      ).flatMap { openCensusMetrics =>
+        BigtableOpenCensusMetrics.metricCollection[IO].map { collection =>
+          assertEquals(
+            openCensusMetrics.count(!_.getTimeSeriesList.isEmpty),
+            collection.counters.size + collection.gauges.size + collection.histograms.size + collection.summaries.size - 1
+          )
+        }
+      }
+    )
+  }
+
+  test("encounters no metric parse errors") {
+    setupInstance.surround(
+      BigtableOpenCensusMetrics.metricCollection[IO].map { collection =>
+        assertEquals(
+          collection.gauges.collectFirst {
+            case ((name, _), values)
+                if name.value == "prometheus4cats_opencensus_parse_errors" =>
+              values.map {
+                case v: LongGauge => v.value
+                case _            => 0L
+              }.sum
+          },
+          Some(0L)
+        )
+      }
+    )
+  }
+
+}

--- a/build.sbt
+++ b/build.sbt
@@ -22,6 +22,8 @@ ThisBuild / scalaVersion := Scala213 // the default Scala
 
 val Prometheus4Cats = "1.0.0-RC3"
 
+val CollectionCompat = "2.8.1"
+
 lazy val root =
   tlCrossRootProject.aggregate(
     catsEffect,
@@ -42,7 +44,7 @@ lazy val catsEffect = project
     libraryDependencies ++= PartialFunction
       .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
         case Some((2, 12)) =>
-          "org.scala-lang.modules" %% "scala-collection-compat" % "2.8.1"
+          "org.scala-lang.modules" %% "scala-collection-compat" % CollectionCompat
       }
       .toList
   )
@@ -90,7 +92,13 @@ lazy val opencensus = project
     libraryDependencies ++= Seq(
       "com.permutive" %% "prometheus4cats" % Prometheus4Cats,
       "io.opencensus" % "opencensus-impl" % "0.31.1"
-    )
+    ),
+    libraryDependencies ++= PartialFunction
+      .condOpt(CrossVersion.partialVersion(scalaVersion.value)) {
+        case Some((2, 12)) =>
+          "org.scala-lang.modules" %% "scala-collection-compat" % CollectionCompat
+      }
+      .toList
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,13 @@ ThisBuild / scalaVersion := Scala213 // the default Scala
 val Prometheus4Cats = "1.0.0-RC3"
 
 lazy val root =
-  tlCrossRootProject.aggregate(catsEffect, trace4Cats, refreshable)
+  tlCrossRootProject.aggregate(
+    catsEffect,
+    trace4Cats,
+    refreshable,
+    googleCloudBigtable,
+    opencensus
+  )
 
 lazy val catsEffect = project
   .in(file("cats-effect"))
@@ -60,6 +66,31 @@ lazy val refreshable = project
       "com.permutive" %% "refreshable" % "0.2.0"
     ),
     mimaPreviousArtifacts := Set.empty
+  )
+
+lazy val googleCloudBigtable = project
+  .in(file("bigtable"))
+  .settings(
+    name := "prometheus4cats-contrib-google-cloud-bigtable",
+    libraryDependencies ++= Seq(
+      "com.permutive" %% "prometheus4cats" % Prometheus4Cats,
+      "com.google.cloud" % "google-cloud-bigtable" % "2.16.0",
+      "org.scalameta" %%% "munit" % "0.7.29" % Test,
+      "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
+      "org.typelevel" %%% "cats-effect-testkit" % "3.4.0" % Test,
+      "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.153.0" % Test
+    )
+  )
+  .dependsOn(opencensus)
+
+lazy val opencensus = project
+  .in(file("opencensus"))
+  .settings(
+    name := "prometheus4cats-contrib-opencensus",
+    libraryDependencies ++= Seq(
+      "com.permutive" %% "prometheus4cats" % Prometheus4Cats,
+      "io.opencensus" % "opencensus-impl" % "0.31.1"
+    )
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -81,7 +81,8 @@ lazy val googleCloudBigtable = project
       "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
       "org.typelevel" %%% "cats-effect-testkit" % "3.4.0" % Test,
       "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.153.0" % Test
-    )
+    ),
+    mimaPreviousArtifacts := Set.empty
   )
   .dependsOn(opencensus)
 
@@ -98,7 +99,8 @@ lazy val opencensus = project
         case Some((2, 12)) =>
           "org.scala-lang.modules" %% "scala-collection-compat" % CollectionCompat
       }
-      .toList
+      .toList,
+    mimaPreviousArtifacts := Set.empty
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
+++ b/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
@@ -31,7 +31,7 @@ import prometheus4cats._
 
 import scala.jdk.CollectionConverters._
 
-// Derivied from https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L82
+// Derived from https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L82
 
 object OpenCensusUtils {
   private val parseErrorsGaugeName: Gauge.Name =

--- a/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
+++ b/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
@@ -184,8 +184,6 @@ object OpenCensusUtils {
               )
           })
         )
-
-      case _ => Right(col)
     }
   }
 

--- a/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
+++ b/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
@@ -1,0 +1,199 @@
+package prometheus4cats.opencensus
+
+import cats.data.NonEmptySeq
+import cats.effect.kernel.Sync
+import cats.syntax.functor._
+import cats.syntax.traverse._
+import io.opencensus.metrics.Metrics
+import io.opencensus.metrics.`export`.{
+  Distribution,
+  Metric,
+  MetricDescriptor,
+  Summary
+}
+import prometheus4cats._
+
+import scala.jdk.CollectionConverters._
+
+// Dervied from https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L82
+
+object OpenCensusUtils {
+  private val parseErrorsGaugeName: Gauge.Name =
+    "prometheus4cats_opencensus_parse_errors"
+  private val parseErrorsExporterLabel: Label.Name = "exporter"
+
+  private def convertMetric(
+      col: MetricCollection,
+      metric: Metric
+  )(formatName: String => String): Either[String, MetricCollection] = {
+    lazy val name = formatName(metric.getMetricDescriptor.getName)
+
+    def parseHelpAndLabels = for {
+      help <- prometheus4cats.Metric.Help.from(
+        metric.getMetricDescriptor.getDescription
+      )
+      labelNames <- metric.getMetricDescriptor.getLabelKeys.asScala.toList
+        .traverse(lk => Label.Name.from(lk.getKey))
+    } yield (help, labelNames.toIndexedSeq)
+
+    def getValues[A](
+        onDouble: Double => Option[A] = (_: Double) => None,
+        onLong: Long => Option[A] = (_: Long) => None,
+        onDistribution: Distribution => Option[A] = (_: Distribution) => None,
+        onSummary: Summary => Option[A] = (_: Summary) => None
+    ): List[(A, IndexedSeq[String])] =
+      metric.getTimeSeriesList.asScala.toList.flatMap { ts =>
+        ts.getPoints.asScala.flatMap { point =>
+          point.getValue
+            .`match`[Option[A]](
+              double => onDouble(double),
+              long => onLong(long),
+              dist => onDistribution(dist),
+              summ => onSummary(summ),
+              _ => None
+            )
+            .tupleRight(
+              ts.getLabelValues.asScala.toIndexedSeq.map(_.getValue)
+            )
+        }
+      }
+
+    metric.getMetricDescriptor.getType match {
+      case MetricDescriptor.Type.CUMULATIVE_INT64 =>
+        for {
+          name <- Counter.Name.from(s"${name}_total")
+          helpAndLabels <- parseHelpAndLabels
+        } yield col.appendLongCounter(
+          name,
+          helpAndLabels._1,
+          helpAndLabels._2,
+          getValues(onLong = Some(_))
+        )
+      case MetricDescriptor.Type.CUMULATIVE_DOUBLE =>
+        for {
+          name <- Counter.Name.from(s"${name}_total")
+          helpAndLabels <- parseHelpAndLabels
+        } yield col.appendDoubleCounter(
+          name,
+          helpAndLabels._1,
+          helpAndLabels._2,
+          getValues(onDouble = Some(_))
+        )
+      case MetricDescriptor.Type.GAUGE_INT64 =>
+        for {
+          name <- Gauge.Name.from(name)
+          helpAndLabels <- parseHelpAndLabels
+        } yield col.appendLongGauge(
+          name,
+          helpAndLabels._1,
+          helpAndLabels._2,
+          getValues(onLong = Some(_))
+        )
+      case MetricDescriptor.Type.GAUGE_DOUBLE =>
+        for {
+          name <- Gauge.Name.from(name)
+          helpAndLabels <- parseHelpAndLabels
+        } yield col.appendDoubleGauge(
+          name,
+          helpAndLabels._1,
+          helpAndLabels._2,
+          getValues(onDouble = Some(_))
+        )
+      case MetricDescriptor.Type.CUMULATIVE_DISTRIBUTION |
+          MetricDescriptor.Type.GAUGE_DISTRIBUTION =>
+        for {
+          name <- Histogram.Name.from(name)
+          helpAndLabels <- parseHelpAndLabels
+        } yield {
+          val values = getValues(onDistribution = { distribution =>
+            Option(distribution.getBucketOptions)
+              .flatMap(
+                _.`match`[Option[NonEmptySeq[Double]]](
+                  explicit =>
+                    NonEmptySeq.fromSeq(
+                      explicit.getBucketBoundaries.asScala
+                        .map[Double](d => d)
+                        .toSeq
+                    ),
+                  _ => None // we only support pre-defined buckets
+                )
+              )
+              .flatMap { boundaries =>
+                NonEmptySeq
+                  .fromSeq(
+                    distribution.getBuckets.asScala
+                      .map(_.getCount.toDouble)
+                      .toSeq
+                  )
+                  .map { bucketValues =>
+                    (
+                      boundaries,
+                      Histogram.Value(distribution.getSum, bucketValues)
+                    )
+                  }
+
+              }
+          })
+
+          values.map(_._1._1).headOption.fold(col) { buckets =>
+            col.appendDoubleHistogram(
+              name,
+              helpAndLabels._1,
+              helpAndLabels._2,
+              buckets,
+              values.map { case ((_, v), ls) => v -> ls }
+            )
+          }
+        }
+      case MetricDescriptor.Type.SUMMARY =>
+        for {
+          name <- prometheus4cats.Summary.Name.from(name)
+          helpAndLabels <- parseHelpAndLabels
+        } yield col.appendDoubleSummary(
+          name,
+          helpAndLabels._1,
+          helpAndLabels._2,
+          getValues[prometheus4cats.Summary.Value[Double]](onSummary = {
+            summary =>
+              Some(
+                prometheus4cats.Summary
+                  .Value(
+                    summary.getCount.toDouble,
+                    summary.getSum,
+                    summary.getSnapshot.getValueAtPercentiles.asScala.map {
+                      valueAtPercentile =>
+                        valueAtPercentile.getPercentile -> valueAtPercentile.getValue
+                    }.toMap
+                  )
+              )
+          })
+        )
+
+      case _ => Right(col)
+    }
+  }
+
+  def openCensusAsMetricCollection[F[_]: Sync](name: String)(
+      metricFilter: Metric => Boolean,
+      formatName: String => String
+  ): F[MetricCollection] = Sync[F]
+    .blocking(
+      Metrics.getExportComponent.getMetricProducerManager.getAllMetricProducer.asScala.toList
+        .flatMap(_.getMetrics.asScala)
+    )
+    .map { metrics =>
+      val (col, parseErrors) = metrics.foldLeft((MetricCollection.empty, 0)) {
+        case ((col, parseErrors), metric) if metricFilter(metric) =>
+          convertMetric(col, metric)(formatName)
+            .fold(_ => (col, parseErrors + 1), (_, parseErrors))
+        case (acc, _) => acc
+      }
+
+      col.appendLongGauge(
+        parseErrorsGaugeName,
+        s"Errors encountered when parsing Open Census metrics",
+        Map(parseErrorsExporterLabel -> name),
+        parseErrors.toLong
+      )
+    }
+}

--- a/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
+++ b/opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2022 Permutive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package prometheus4cats.opencensus
 
 import cats.data.NonEmptySeq
@@ -15,7 +31,7 @@ import prometheus4cats._
 
 import scala.jdk.CollectionConverters._
 
-// Dervied from https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L82
+// Derivied from https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java#L82
 
 object OpenCensusUtils {
   private val parseErrorsGaugeName: Gauge.Name =
@@ -112,8 +128,8 @@ object OpenCensusUtils {
                   explicit =>
                     NonEmptySeq.fromSeq(
                       explicit.getBucketBoundaries.asScala
-                        .map[Double](d => d)
-                        .toSeq
+                        .map(_.toDouble)
+                        .toList
                     ),
                   _ => None // we only support pre-defined buckets
                 )
@@ -123,7 +139,7 @@ object OpenCensusUtils {
                   .fromSeq(
                     distribution.getBuckets.asScala
                       .map(_.getCount.toDouble)
-                      .toSeq
+                      .toList
                   )
                   .map { bucketValues =>
                     (
@@ -191,7 +207,7 @@ object OpenCensusUtils {
 
       col.appendLongGauge(
         parseErrorsGaugeName,
-        s"Errors encountered when parsing Open Census metrics",
+        "Errors encountered when parsing Open Census metrics",
         Map(parseErrorsExporterLabel -> name),
         parseErrors.toLong
       )


### PR DESCRIPTION
Adds a couple of modules:

- OpenCensus, which can get a `MetricCollection` from the OpenCensus registry, converting their horrible types into our nice types 😉 
- Bigtable, which uses the OpenCensus module to collect Bigtable client metrics for exposure to Prometheus. A test has been added to make sure the expected metrics are present and are aligned correctly