### PR TITLE
Instrument an existing `Refreshable`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 // https://typelevel.org/sbt-typelevel/faq.html#what-is-a-base-version-anyway
-ThisBuild / tlBaseVersion := "0.1" // your current series x.y
+ThisBuild / tlBaseVersion := "0.2" // your current series x.y
 
 ThisBuild / organization := "com.permutive"
 ThisBuild / organizationName := "Permutive"
@@ -66,8 +66,7 @@ lazy val refreshable = project
     libraryDependencies ++= Seq(
       "com.permutive" %% "prometheus4cats" % Prometheus4Cats,
       "com.permutive" %% "refreshable" % "0.2.0"
-    ),
-    mimaPreviousArtifacts := Set.empty
+    )
   )
 
 lazy val googleCloudBigtable = project
@@ -81,8 +80,7 @@ lazy val googleCloudBigtable = project
       "org.typelevel" %%% "munit-cats-effect-3" % "1.0.7" % Test,
       "org.typelevel" %%% "cats-effect-testkit" % "3.4.0" % Test,
       "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.153.0" % Test
-    ),
-    mimaPreviousArtifacts := Set.empty
+    )
   )
   .dependsOn(opencensus)
 
@@ -99,8 +97,7 @@ lazy val opencensus = project
         case Some((2, 12)) =>
           "org.scala-lang.modules" %% "scala-collection-compat" % CollectionCompat
       }
-      .toList,
-    mimaPreviousArtifacts := Set.empty
+      .toList
   )
 
 lazy val docs = project.in(file("site")).enablePlugins(TypelevelSitePlugin)

--- a/refreshable/src/main/scala/prometheus4cats/refreshable/InstrumentedRefreshable.scala
+++ b/refreshable/src/main/scala/prometheus4cats/refreshable/InstrumentedRefreshable.scala
@@ -16,13 +16,15 @@
 
 package prometheus4cats.refreshable
 
-import cats.Applicative
 import cats.effect.kernel.syntax.monadCancel._
 import cats.effect.kernel.syntax.resource._
-import cats.effect.kernel.{MonadCancel, MonadCancelThrow, Resource}
+import cats.effect.kernel.syntax.spawn._
+import cats.effect.kernel.{Async, MonadCancel, MonadCancelThrow, Resource}
+import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.foldable._
 import cats.syntax.functor._
+import cats.{Applicative, Functor}
 import com.permutive.refreshable.{CachedValue, Refreshable}
 import prometheus4cats._
 import retry.RetryDetails
@@ -65,6 +67,107 @@ object InstrumentedRefreshable {
   private val prefix: Metric.Prefix = "refreshable"
   private val refreshableLabelName: Label.Name = "refreshable_name"
 
+  private def instanceMetrics[F[_]: MonadCancelThrow, A](
+      metricFactory: MetricFactory[F]
+  ): F[
+    (
+        Counter.Labelled[F, Long, (String, CachedValue[A])],
+        Gauge.Labelled[F, Boolean, String],
+        Gauge.Labelled[F, Boolean, String]
+    )
+  ] = {
+    val factory = metricFactory.withPrefix(prefix)
+
+    (
+      factory
+        .counter("read_total")
+        .ofLong
+        .help("Number of times this Refreshable has been read")
+        .label[String](refreshableLabelName)
+        .label[CachedValue[A]](
+          "value_state",
+          {
+            case CachedValue.Success(_)   => "success"
+            case CachedValue.Error(_, _)  => "error"
+            case CachedValue.Cancelled(_) => "cancelled"
+          }
+        )
+        .unsafeBuild,
+      factory
+        .gauge("is_running")
+        .ofLong
+        .help("Whether this Refreshable is running or has been cancelled")
+        .label[String](refreshableLabelName)
+        .contramap[Boolean](if (_) 1L else 0L)
+        .unsafeBuild,
+      factory
+        .gauge("retries_exhausted")
+        .ofLong
+        .help("Whether retries have been exhausted for this Refreshable")
+        .label[String](refreshableLabelName)
+        .contramap[Boolean](if (_) 1L else 0L)
+        .unsafeBuild
+    ).tupled
+  }
+
+  private def callbackMetrics[F[_]: MonadCancelThrow](
+      metricFactory: MetricFactory[F]
+  ): F[
+    (
+        Counter.Labelled[F, Long, String],
+        Gauge.Labelled[F, Boolean, String],
+        Counter.Labelled[F, Long, String]
+    )
+  ] = {
+    val factory = metricFactory.withPrefix(prefix)
+
+    (
+      factory
+        .counter("refresh_success_total")
+        .ofLong
+        .help("Number of times refresh succeeded")
+        .label[String](refreshableLabelName)
+        .unsafeBuild,
+      factory
+        .gauge("refresh_failing")
+        .ofLong
+        .help("Whether refresh is currently failing")
+        .label[String](refreshableLabelName)
+        .contramap[Boolean](if (_) 1L else 0L)
+        .unsafeBuild,
+      factory
+        .counter("refresh_failure_total")
+        .ofLong
+        .help("Number of times refresh failed")
+        .label[String](refreshableLabelName)
+        .unsafeBuild
+    ).tupled
+  }
+
+  // TODO this might need a new release of prometheus4cats so multiple label values can be returned to represent when
+  //  there are no errors or no cancellation, we'll have to see how this looks in prometheus
+  private def callback[F[_]: Functor, A](
+      name: String,
+      refreshable: Refreshable[F, A],
+      metricFactory: MetricFactory.WithCallbacks[F]
+  ): Resource[F, Unit] =
+    metricFactory
+      .withPrefix(prefix)
+      .gauge("status")
+      .ofLong
+      .help("The current status of this Refreshable")
+      .label[String](refreshableLabelName)
+      .label[CachedValue[A]](
+        "value_state",
+        {
+          case CachedValue.Success(_)   => "success"
+          case CachedValue.Error(_, _)  => "error"
+          case CachedValue.Cancelled(_) => "cancelled"
+        }
+      )
+      .callback(refreshable.get.map { v => (1, (name, v)) })
+      .build
+
   private def metrics[F[_]: MonadCancelThrow, A](
       name: String,
       metricFactory: MetricFactory[F]
@@ -84,106 +187,60 @@ object InstrumentedRefreshable {
         PartialFunction[Throwable, F[Unit]]
     )
   ] = {
-    val factory = metricFactory.withPrefix(prefix)
 
-    for {
-      refreshSuccessCounter <- factory
-        .counter("refresh_success_total")
-        .ofLong
-        .help("Number of times refresh succeeded")
-        .label[String](refreshableLabelName)
-        .unsafeBuild
+    (instanceMetrics[F, A](metricFactory), callbackMetrics(metricFactory))
+      .mapN {
+        case (
+              (readCounter, runningGauge, exhaustedRetriesGauge),
+              (
+                refreshSuccessCounter,
+                currentlyFailingGauge,
+                refreshFailureCounter
+              )
+            ) =>
+          val onNewValue: (A, FiniteDuration) => F[Unit] =
+            (a, nextRefresh) =>
+              currentOnNewValue
+                .fold(Applicative[F].unit)(_(a, nextRefresh))
+                .guarantee(
+                  refreshSuccessCounter
+                    .inc(name) >> currentlyFailingGauge
+                    .set(false, name)
+                )
 
-      currentlyFailingGauge <- factory
-        .gauge("refresh_failing")
-        .ofLong
-        .help("Whether refresh is currently failing")
-        .label[String](refreshableLabelName)
-        .contramap[Boolean](if (_) 1L else 0L)
-        .unsafeBuild
-
-      refreshFailureCounter <- factory
-        .counter("refresh_failure_total")
-        .ofLong
-        .help("Number of times refresh failed")
-        .label[String](refreshableLabelName)
-        .unsafeBuild
-
-      exhaustedRetriesGauge <- factory
-        .gauge("retries_exhausted")
-        .ofLong
-        .help("Whether retries have been exhausted for this Refreshable")
-        .label[String](refreshableLabelName)
-        .contramap[Boolean](if (_) 1L else 0L)
-        .unsafeBuild
-
-      readCounter <- factory
-        .counter("read_total")
-        .ofLong
-        .help("Number of times this Refreshable has been read")
-        .label[String](refreshableLabelName)
-        .label[CachedValue[A]](
-          "value_state",
-          {
-            case CachedValue.Success(_)   => "success"
-            case CachedValue.Error(_, _)  => "error"
-            case CachedValue.Cancelled(_) => "cancelled"
+          val onRefreshFailure: PartialFunction[(Throwable, RetryDetails), F[
+            Unit
+          ]] = { case err =>
+            currentOnRefreshFailure
+              .lift(err)
+              .sequence_
+              .guarantee(
+                refreshFailureCounter
+                  .inc(name) >> currentlyFailingGauge
+                  .set(true, name)
+              )
           }
-        )
-        .unsafeBuild
 
-      runningGauge <- factory
-        .gauge("is_running")
-        .ofLong
-        .help("Whether this Refreshable is running or has been cancelled")
-        .label[String](refreshableLabelName)
-        .contramap[Boolean](if (_) 1L else 0L)
-        .unsafeBuild
+          val onExhaustedRetries: PartialFunction[Throwable, F[Unit]] = {
+            case err =>
+              currentOnExhaustedRetries
+                .lift(err)
+                .sequence_
+                .guarantee(
+                  exhaustedRetriesGauge.set(true, name) >> runningGauge
+                    .set(false, name)
+                )
+          }
 
-    } yield {
-      val onNewValue: (A, FiniteDuration) => F[Unit] =
-        (a, nextRefresh) =>
-          currentOnNewValue
-            .fold(Applicative[F].unit)(_(a, nextRefresh))
-            .guarantee(
-              refreshSuccessCounter
-                .inc(name) >> currentlyFailingGauge
-                .set(false, name)
-            )
-
-      val onRefreshFailure: PartialFunction[(Throwable, RetryDetails), F[
-        Unit
-      ]] = { case err =>
-        currentOnRefreshFailure
-          .lift(err)
-          .sequence_
-          .guarantee(
-            refreshFailureCounter
-              .inc(name) >> currentlyFailingGauge
-              .set(true, name)
+          (
+            readCounter,
+            runningGauge,
+            exhaustedRetriesGauge,
+            onNewValue,
+            onRefreshFailure,
+            onExhaustedRetries
           )
       }
-
-      val onExhaustedRetries: PartialFunction[Throwable, F[Unit]] = {
-        case err =>
-          currentOnExhaustedRetries
-            .lift(err)
-            .sequence_
-            .guarantee(
-              exhaustedRetriesGauge.set(true, name) >> runningGauge
-                .set(false, name)
-            )
-      }
-
-      (
-        readCounter,
-        runningGauge,
-        exhaustedRetriesGauge,
-        onNewValue,
-        onRefreshFailure,
-        onExhaustedRetries
-      )
-    }
   }
 
   class Updates[F[_], A](
@@ -209,7 +266,7 @@ object InstrumentedRefreshable {
     def create[F[_]: MonadCancelThrow, A](
         builder: Refreshable.UpdatesBuilder[F, A],
         name: String,
-        metricFactory: MetricFactory[F]
+        metricFactory: MetricFactory.WithCallbacks[F]
     ): Resource[F, Updates[F, A]] = metrics(name, metricFactory)(
       builder.newValueCallback,
       builder.refreshFailureCallback,
@@ -229,6 +286,7 @@ object InstrumentedRefreshable {
           .onExhaustedRetries(onExhaustedRetries)
           .resource
           .evalTap(_ => runningGauge.set(true, name))
+          .flatTap(callback(name, _, metricFactory))
           .map { refreshable =>
             new InstrumentedRefreshable.Updates[F, A](
               refreshable,
@@ -239,12 +297,62 @@ object InstrumentedRefreshable {
             )
           }
     }
+
+    def fromExisting[F[_]: Async, A](
+        refreshable: Refreshable.Updates[F, A],
+        name: String,
+        metricFactory: MetricFactory.WithCallbacks[F]
+    ): Resource[F, InstrumentedRefreshable.Updates[F, A]] =
+      (
+        instanceMetrics[F, A](metricFactory).toResource,
+        callbackMetrics(metricFactory).toResource
+      )
+        .flatMapN {
+          case (
+                (readCounter, runningGauge, exhaustedRetriesGauge),
+                (
+                  refreshSuccessCounter,
+                  currentlyFailingGauge,
+                  refreshFailureCounter
+                )
+              ) =>
+            callback(name, refreshable, metricFactory).evalTap(_ =>
+              runningGauge.set(true, name)
+            ) >> refreshable.updates
+              .evalMap {
+                case CachedValue.Success(_) =>
+                  refreshSuccessCounter
+                    .inc(name) >> currentlyFailingGauge.set(
+                    false,
+                    name
+                  ) >> runningGauge.set(true, name)
+                case CachedValue.Error(_, _) =>
+                  refreshFailureCounter
+                    .inc(name) >> currentlyFailingGauge.set(
+                    true,
+                    name
+                  ) >> runningGauge.set(true, name)
+                case CachedValue.Cancelled(_) => runningGauge.set(false, name)
+              }
+              .compile
+              .drain
+              .background
+              .as(
+                new InstrumentedRefreshable.Updates[F, A](
+                  refreshable,
+                  name,
+                  readCounter,
+                  runningGauge,
+                  exhaustedRetriesGauge
+                )
+              )
+        }
   }
 
   def create[F[_]: MonadCancelThrow, A](
       builder: Refreshable.RefreshableBuilder[F, A],
       name: String,
-      metricFactory: MetricFactory[F]
+      metricFactory: MetricFactory.WithCallbacks[F]
   ): Resource[F, InstrumentedRefreshable[F, A]] =
     metrics(name, metricFactory)(
       builder.newValueCallback,
@@ -265,6 +373,7 @@ object InstrumentedRefreshable {
           .onExhaustedRetries(onExhaustedRetries)
           .resource
           .evalTap(_ => runningGauge.set(true, name))
+          .flatTap(callback(name, _, metricFactory))
           .map { refreshable =>
             new InstrumentedRefreshable[F, A](
               refreshable,
@@ -275,5 +384,41 @@ object InstrumentedRefreshable {
             )
           }
     }
+
+  def fromExisting[F[_]: MonadCancelThrow, A](
+      refreshable: Refreshable[F, A],
+      name: String,
+      metricFactory: MetricFactory.WithCallbacks[F]
+  ): Resource[F, InstrumentedRefreshable[F, A]] =
+    instanceMetrics[F, A](metricFactory).toResource
+      .flatTap(_ => callback(name, refreshable, metricFactory))
+      .evalMap { case (readCounter, runningGauge, exhaustedRetriesGauge) =>
+        runningGauge
+          .set(true, name)
+          .as {
+            // Set the running gauge on read as we can't do this via callback or from the stream
+            val setRunningGauge = MonadCancelThrow[F].uncancelable { poll =>
+              poll(
+                refreshable.get.flatTap(value =>
+                  readCounter.inc(name -> value) >> (value match {
+                    case CachedValue.Cancelled(_) =>
+                      runningGauge.set(false, name)
+                    case _ => runningGauge.set(true, name)
+                  })
+                )
+              )
+            }
+
+            new InstrumentedRefreshable[F, A](
+              refreshable,
+              name,
+              readCounter,
+              runningGauge,
+              exhaustedRetriesGauge
+            ) {
+              override def get: F[CachedValue[A]] = setRunningGauge
+            }
+          }
+      }
 
 }


### PR DESCRIPTION
- Use a metric callback to get the current state of the refreshable
- Monitor the stream of updates and set metrics accordingly for the `Refreshable.Updates` version
- Use the `get` call to set the running gauge state on read for the standard refreshable