### PR TITLE
Do not return previous exemplar in sampler

### DIFF
--- a/trace4cats/src/main/scala/prometheus4cats/trace4cats/Trace4CatsExemplarSampler.scala
+++ b/trace4cats/src/main/scala/prometheus4cats/trace4cats/Trace4CatsExemplarSampler.scala
@@ -132,7 +132,6 @@ object Trace4CatsExemplarSampler extends Trace4CatsExemplarSamplerInstances {
           .filter(
             _.timestamp.toEpochMilli - prev.timestamp.toEpochMilli > minRetentionIntervalMs
           )
-          .orElse(previous)
       case None => next
     }
   }


### PR DESCRIPTION
This avoids prom4cats unecessarily updating the exemplar ref when the exemplar is not sampled. If this returns `None` then the ref won't be updated and the previous will remain intact