### PR TITLE
Bump prometheus4cats to v6.0.0 across all contrib modules

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion           := "2.13.18"
 ThisBuild / crossScalaVersions     := Seq("2.13.18", "3.3.7")
 ThisBuild / organization           := "com.permutive"
-ThisBuild / versionPolicyIntention := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc; publishLocal; +test")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
+++ b/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
@@ -121,9 +121,9 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
     )
   }
 
-  /** Returns the names of all metrics currently registered in the registry. v5 had `metricFamilySamples()`
-    * returning an enumeration of `MetricFamilySamples` with `.name`; v6 has `scrape()` returning
-    * `MetricSnapshots` with `getMetadata.getName`. We just need names for these tests.
+  /** Returns the names of all metrics currently registered in the registry. v5 had `metricFamilySamples()` returning an
+    * enumeration of `MetricFamilySamples` with `.name`; v6 has `scrape()` returning `MetricSnapshots` with
+    * `getMetadata.getName`. We just need names for these tests.
     */
   private def metricNames(reg: PrometheusRegistry): List[String] =
     reg.scrape().asScala.toList.map(_.getMetadata.getName)

--- a/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
+++ b/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
@@ -28,13 +28,13 @@ import cats.syntax.all._
 import com.dimafeng.testcontainers.KafkaContainer
 import com.dimafeng.testcontainers.munit.TestContainerForAll
 import fs2.kafka._
-import io.prometheus.client.CollectorRegistry
+import io.prometheus.metrics.model.registry.PrometheusRegistry
 import munit.CatsEffectSuite
 import org.apache.kafka.clients.admin.NewTopic
 import org.apache.kafka.clients.consumer.ConsumerConfig
 import org.apache.kafka.clients.producer.ProducerConfig
 import prometheus4cats.MetricFactory
-import prometheus4cats.javasimpleclient.JavaMetricRegistry
+import prometheus4cats.javaclient.JavaMetricRegistry
 
 class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
 
@@ -121,8 +121,15 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
     )
   }
 
+  /** Returns the names of all metrics currently registered in the registry. v5 had `metricFamilySamples()`
+    * returning an enumeration of `MetricFamilySamples` with `.name`; v6 has `scrape()` returning
+    * `MetricSnapshots` with `getMetadata.getName`. We just need names for these tests.
+    */
+  private def metricNames(reg: PrometheusRegistry): List[String] =
+    reg.scrape().asScala.toList.map(_.getMetadata.getName)
+
   val factory =
-    Resource.eval(IO.delay(new CollectorRegistry())).flatMap { reg =>
+    Resource.eval(IO.delay(new PrometheusRegistry())).flatMap { reg =>
       JavaMetricRegistry
         .Builder[IO]()
         .withRegistry(reg)
@@ -150,19 +157,11 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
               consumer.subscribeTo(
                 topic
               ) >> consumer.stream.take(1).compile.drain >> IO
-                .delay(registry.metricFamilySamples().asScala.toList)
-                .map { samples =>
-                  assertEquals(
-                    samples
-                      .find(
-                        _.name === "prometheus4cats_collection_callback_duplicates"
-                      )
-                      .map(_.samples.isEmpty),
-                    Some(true)
-                  )
+                .delay(metricNames(registry))
+                .map { names =>
                   assert(
-                    samples
-                      .exists(_.name.startsWith("kafka_client_consumer"))
+                    names
+                      .exists(_.startsWith("kafka_client_consumer"))
                   )
                 }
           )
@@ -204,19 +203,11 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
                     .subscribeTo(
                       topic2
                     ) >> consumer2.stream.take(1).compile.drain >> IO
-                    .delay(registry.metricFamilySamples().asScala.toList)
-                    .map { samples =>
-                      assertEquals(
-                        samples
-                          .find(
-                            _.name === "prometheus4cats_collection_callback_duplicates"
-                          )
-                          .map(_.samples.isEmpty),
-                        Some(true)
-                      )
+                    .delay(metricNames(registry))
+                    .map { names =>
                       assert(
-                        samples.exists(
-                          _.name.startsWith("kafka_client_consumer")
+                        names.exists(
+                          _.startsWith("kafka_client_consumer")
                         )
                       )
                     }
@@ -243,22 +234,14 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
                 )
               )
               .flatten >> IO
-              .delay(registry.metricFamilySamples().asScala.toList)
-              .map { samples =>
-                assertEquals(
-                  samples
-                    .find(
-                      _.name === "prometheus4cats_collection_callback_duplicates"
-                    )
-                    .map(_.samples.isEmpty),
-                  Some(true)
+              .delay(metricNames(registry))
+              .map { names =>
+                assert(
+                  names.exists(_.startsWith("kafka_client_producer"))
                 )
                 assert(
-                  samples.exists(_.name.startsWith("kafka_client_producer"))
-                )
-                assert(
-                  samples
-                    .exists(_.name.startsWith("kafka_client_producer_node"))
+                  names
+                    .exists(_.startsWith("kafka_client_producer_node"))
                 )
               }
           )
@@ -296,21 +279,14 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
                     records
                   )
                   .flatten >> IO
-                  .delay(registry.metricFamilySamples().asScala.toList)
-                  .map { samples =>
+                  .delay(metricNames(registry))
+                  .map { names =>
                     assert(
-                      samples
-                        .find(
-                          _.name === "prometheus4cats_collection_callback_duplicates"
-                        )
-                        .forall(_.samples.isEmpty)
+                      names.exists(_.startsWith("kafka_client_producer"))
                     )
                     assert(
-                      samples.exists(_.name.startsWith("kafka_client_producer"))
-                    )
-                    assert(
-                      samples
-                        .exists(_.name.startsWith("kafka_client_producer_node"))
+                      names
+                        .exists(_.startsWith("kafka_client_producer_node"))
                     )
                   }
               )
@@ -340,22 +316,14 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
               .produceWithoutOffsets(
                 ProducerRecords(List(ProducerRecord(topic, "test", "test")))
               ) >> IO
-              .delay(registry.metricFamilySamples().asScala.toList)
-              .map { samples =>
-                assertEquals(
-                  samples
-                    .find(
-                      _.name === "prometheus4cats_collection_callback_duplicates"
-                    )
-                    .map(_.samples.isEmpty),
-                  Some(true)
+              .delay(metricNames(registry))
+              .map { names =>
+                assert(
+                  names.exists(_.startsWith("kafka_client_producer"))
                 )
                 assert(
-                  samples.exists(_.name.startsWith("kafka_client_producer"))
-                )
-                assert(
-                  samples
-                    .exists(_.name.startsWith("kafka_client_producer_node"))
+                  names
+                    .exists(_.startsWith("kafka_client_producer_node"))
                 )
               }
           )
@@ -398,24 +366,16 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
                   .produceWithoutOffsets(
                     records
                   ) >> IO
-                  .delay(registry.metricFamilySamples().asScala.toList)
-                  .map { samples =>
-                    assertEquals(
-                      samples
-                        .find(
-                          _.name === "prometheus4cats_collection_callback_duplicates"
-                        )
-                        .map(_.samples.isEmpty),
-                      Some(true)
-                    )
+                  .delay(metricNames(registry))
+                  .map { names =>
                     assert(
-                      samples.exists(
-                        _.name.startsWith("kafka_client_producer")
+                      names.exists(
+                        _.startsWith("kafka_client_producer")
                       )
                     )
                     assert(
-                      samples.exists(
-                        _.name.startsWith("kafka_client_producer_node")
+                      names.exists(
+                        _.startsWith("kafka_client_producer_node")
                       )
                     )
                   }

--- a/modules/prometheus4cats-contrib-opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
+++ b/modules/prometheus4cats-contrib-opencensus/src/main/scala/prometheus4cats/opencensus/OpenCensusUtils.scala
@@ -172,7 +172,7 @@ object OpenCensusUtils {
             Some(
               prometheus4cats.Summary
                 .Value(
-                  summary.getCount.toDouble,
+                  summary.getCount,
                   summary.getSum,
                   summary.getSnapshot.getValueAtPercentiles.asScala.map { valueAtPercentile =>
                     valueAtPercentile.getPercentile -> valueAtPercentile.getValue

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,23 +5,23 @@ object Dependencies {
   lazy val `kind-projector` = compilerPlugin(("org.typelevel" % "kind-projector" % "0.13.4").cross(CrossVersion.full))
 
   lazy val `prometheus4cats-contrib-cats-effect` = Seq(
-    "com.permutive" %% "prometheus4cats" % "5.0.0",
+    "com.permutive" %% "prometheus4cats" % "6.0.0",
     "org.typelevel" %% "cats-effect"     % "3.6.3"
   )
 
   lazy val `prometheus4cats-contrib-trace4cats` = Seq(
-    "com.permutive"    %% "prometheus4cats" % "5.0.0",
+    "com.permutive"    %% "prometheus4cats" % "6.0.0",
     "io.janstenpickle" %% "trace4cats-core" % "0.14.7"
   )
 
   lazy val `prometheus4cats-contrib-refreshable` = Seq(
-    "com.permutive" %% "prometheus4cats" % "5.0.0",
+    "com.permutive" %% "prometheus4cats" % "6.0.0",
     "com.permutive" %% "refreshable"     % "2.1.1"
   )
 
   lazy val `prometheus4cats-contrib-google-cloud-bigtable` = Seq(
     "com.google.cloud" % "google-cloud-bigtable" % "2.65.1",
-    "com.permutive"   %% "prometheus4cats"       % "5.0.0"
+    "com.permutive"   %% "prometheus4cats" % "6.0.0"
   ) ++ Seq(
     "com.google.cloud" % "google-cloud-bigtable-emulator" % "0.202.1",
     "org.scalameta"   %% "munit"                          % "1.2.1",
@@ -30,23 +30,23 @@ object Dependencies {
   ).map(_ % Test)
 
   lazy val `prometheus4cats-contrib-opencensus` = Seq(
-    "com.permutive" %% "prometheus4cats" % "5.0.0",
+    "com.permutive" %% "prometheus4cats" % "6.0.0",
     "io.opencensus"  % "opencensus-impl" % "0.31.1"
   )
 
   lazy val `prometheus4cats-contrib-fs2-kafka` = Seq(
     "com.github.fd4s" %% "fs2-kafka"       % "3.9.1",
-    "com.permutive"   %% "prometheus4cats" % "5.0.0"
+    "com.permutive"   %% "prometheus4cats" % "6.0.0"
   ) ++ Seq(
     "com.dimafeng"  %% "testcontainers-scala-kafka" % "0.43.6",
     "com.dimafeng"  %% "testcontainers-scala-munit" % "0.43.6",
-    "com.permutive" %% "prometheus4cats-java"       % "5.0.0",
+    "com.permutive" %% "prometheus4cats-java" % "6.0.0",
     "org.typelevel" %% "cats-effect-testkit"        % "3.6.3",
     "org.typelevel" %% "munit-cats-effect"          % "2.1.0"
   ).map(_ % Test)
 
   lazy val `prometheus4cats-contrib-circuit` = Seq(
-    "com.permutive"     %% "prometheus4cats" % "5.0.0",
+    "com.permutive"     %% "prometheus4cats" % "6.0.0",
     "io.chrisdavenport" %% "circuit"         % "0.5.1"
   )
 


### PR DESCRIPTION
## Summary

Lockstep uplift of `prometheus4cats-contrib-*` against [prometheus4cats #124](https://github.com/permutive-engineering/prometheus4cats/pull/124) (the v6 library cut). Bumps the core `prometheus4cats` dep from 5.0.0 → 6.0.0 across all seven contrib modules.

**⚠️ CI will fail until #124 lands and `prometheus4cats 6.0.0` publishes to Maven Central.** Opening as draft so reviewers can comment in parallel.

## What changes

`project/Dependencies.scala` — every `prometheus4cats` / `prometheus4cats-java` 5.0.0 reference bumped to 6.0.0. Modules affected: `cats-effect`, `trace4cats`, `refreshable`, `google-cloud-bigtable`, `opencensus`, `fs2-kafka`, `circuit`.

`build.sbt` — `versionPolicyIntention` flipped to `Compatibility.None` matching the prometheus4cats main repo. Each contrib's own public API surface re-exports prometheus4cats types (e.g. `Summary.Value[Double]`), so v6's source-incompatible changes (`Summary.Value.count: Double → Long`, `Info` redesign, package rename) cascade through. mima/`versionPolicyCheck` would flag this anyway; setting the intention upfront is the honest signal.

### Non-trivial source changes

- **`prometheus4cats-contrib-opencensus / OpenCensusUtils.scala`** — `summary.getCount.toDouble` → `summary.getCount`. The opencensus API already returns `long`; v6's `Summary.Value.count: Long` accepts that directly without the previous `.toDouble` round-trip.
- **`prometheus4cats-contrib-fs2-kafka / KafkaMetricsSuite.scala`** — rewrote the test idioms onto v6's `PrometheusRegistry.scrape()` (was the simpleclient `metricFamilySamples()` API). Added a small `metricNames(reg)` helper for assertion terseness. **Dropped 6 `prometheus4cats_collection_callback_duplicates` self-metric assertions** — that metric was part of the v5-only self-observability set the v6 javaclient backend doesn't yet emit. The test was using it as a diagnostic probe (asserting `.samples.isEmpty` to verify no duplicate registrations during setup); v6's stricter collision-detection throws `IllegalArgumentException` at registration time, so the probe is redundant and the original test invariant is preserved by the eager throw. See [#124's open question](https://github.com/permutive-engineering/prometheus4cats/pull/124#issuecomment-4352612003) about whether to re-add the self-metrics in general.

## Test results

`+compile` and `+Test/compile` green on Scala 2.13.18 + 3.3.7 against a local `publishLocal` of prometheus4cats 6.0.0.

Full `+test` cycle blocked by the Kafka testcontainer (Docker required) — local CI passes the compile gate; the testcontainer suite will run when CI does after #124 publishes.

## Test plan

- [ ] CI green once `prometheus4cats 6.0.0` publishes to Maven Central
- [ ] Cross-build (Scala 2.13 + 3.3) on the platform
- [ ] Kafka testcontainer suite runs in CI
