### PR TITLE
Roll back fs2-kafka 4.0.0 → fd4s 3.9.1

### DIFF
--- a/modules/prometheus4cats-contrib-fs2-kafka/src/main/scala/prometheus4cats/fs2kafka/KafkaMetrics.scala
+++ b/modules/prometheus4cats-contrib-fs2-kafka/src/main/scala/prometheus4cats/fs2kafka/KafkaMetrics.scala
@@ -27,6 +27,7 @@ import cats.syntax.all._
 
 import fs2.kafka.KafkaConsumer
 import fs2.kafka.KafkaProducer
+import fs2.kafka.TransactionalKafkaProducer
 import io.prometheus.metrics.model.registry.PrometheusRegistry
 import org.apache.kafka.common.MetricName
 import org.apache.kafka.common.{Metric => KafkaMetric}
@@ -281,7 +282,7 @@ object KafkaMetrics {
 
   def registerProducerCallback[F[_]: Async, K, V](
       registry: PrometheusRegistry,
-      producer: KafkaProducer[F, K, V],
+      producer: KafkaProducer.Metrics[F, K, V],
       producerName: String
   ): Resource[F, Unit] = MetricCollectionCollector.register[F](
     registry,
@@ -298,7 +299,7 @@ object KafkaMetrics {
 
   def registerTransactionalProducerCallback[F[_]: Async, K, V](
       registry: PrometheusRegistry,
-      producer: KafkaProducer[F, K, V],
+      producer: TransactionalKafkaProducer.Metrics[F, K, V],
       producerName: String
   ): Resource[F, Unit] = MetricCollectionCollector.register[F](
     registry,

--- a/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
+++ b/modules/prometheus4cats-contrib-fs2-kafka/src/test/scala/prometheus4cats/fs2kafka/KafkaMetricsSuite.scala
@@ -86,7 +86,7 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
   final def producerResource[K, V](implicit
       k: KeySerializer[IO, K],
       v: ValueSerializer[IO, V]
-  ): Resource[IO, KafkaProducer[IO, K, V]] =
+  ): Resource[IO, KafkaProducer.Metrics[IO, K, V]] =
     KafkaProducer.resource(
       ProducerSettings[IO, K, V].withProperties(defaultProducerConfig)
     )
@@ -94,12 +94,14 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
   final def transactionalProducerResource[K, V](implicit
       k: KeySerializer[IO, K],
       v: ValueSerializer[IO, V]
-  ): Resource[IO, KafkaProducer[IO, K, V]] =
-    KafkaProducer.transactional(
-      ProducerSettings[IO, K, V]
-        .withProperties(defaultProducerConfig)
-        .withRetries(1)
-        .withTransactionalId(UUID.randomUUID().show)
+  ): Resource[IO, TransactionalKafkaProducer.WithoutOffsets[IO, K, V]] =
+    TransactionalKafkaProducer.resource(
+      TransactionalProducerSettings[IO, K, V](
+        UUID.randomUUID().show,
+        ProducerSettings[IO, K, V]
+          .withProperties(defaultProducerConfig)
+          .withRetries(1)
+      )
     )
 
   final def defaultProducerConfig = withContainers { container =>
@@ -304,7 +306,7 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
           )
           .surround(
             producer
-              .produceTransactionally(
+              .produceWithoutOffsets(
                 ProducerRecords(List(ProducerRecord(topic, "test", "test")))
               ) >> IO
               .delay(registry.scrape().asScala.toList)
@@ -344,7 +346,7 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
           )
           .surround(
             producer1
-              .produceTransactionally(
+              .produceWithoutOffsets(
                 records
               ) >> KafkaMetrics
               .registerTransactionalProducerCallback(
@@ -354,7 +356,7 @@ class KafkaMetricsSuite extends CatsEffectSuite with TestContainerForAll {
               )
               .surround(
                 producer2
-                  .produceTransactionally(
+                  .produceWithoutOffsets(
                     records
                   ) >> IO
                   .delay(registry.scrape().asScala.toList)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   )
 
   lazy val `prometheus4cats-contrib-fs2-kafka` = Seq(
-    "org.typelevel" %% "fs2-kafka"                % "4.0.0",
+    "com.github.fd4s" %% "fs2-kafka"          % "3.9.1",
     "com.permutive" %% "prometheus4cats"          % "6.0.0-RC3",
     "io.prometheus"  % "prometheus-metrics-model" % "1.6.1"
   ) ++ Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,9 +37,9 @@ object Dependencies {
   )
 
   lazy val `prometheus4cats-contrib-fs2-kafka` = Seq(
-    "com.github.fd4s" %% "fs2-kafka"          % "3.9.1",
-    "com.permutive" %% "prometheus4cats"          % "6.0.0-RC3",
-    "io.prometheus"  % "prometheus-metrics-model" % "1.6.1"
+    "com.github.fd4s" %% "fs2-kafka"                % "3.9.1",
+    "com.permutive"   %% "prometheus4cats"          % "6.0.0-RC3",
+    "io.prometheus"    % "prometheus-metrics-model" % "1.6.1"
   ) ++ Seq(
     "com.dimafeng"  %% "testcontainers-scala-kafka" % "0.44.1",
     "com.dimafeng"  %% "testcontainers-scala-munit" % "0.44.1",


### PR DESCRIPTION
Reverting fs2-kafka dependency bump.